### PR TITLE
First version of private-mode, invite-only WeChat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-wechat",
   "description": "WeChat Social Provider for freedomjs",
-  "version": "0.1.11",
+  "version": "0.1.13",
   "repository": {
     "type": "git",
     "url": "https://github.com/freedomjs/freedom-social-wechat.git"

--- a/src/social.wechat.json
+++ b/src/social.wechat.json
@@ -3,8 +3,8 @@
   "description": "Social provider using WeChat",
   "app": {
     "script": [
-      "wechat-social-provider.js"
-   	]
+      "wechat-social-provider.static.js"
+    ]
   },
   "dependencies": {
     "pgp-e2e": {

--- a/src/wechat-social-provider.js
+++ b/src/wechat-social-provider.js
@@ -452,11 +452,11 @@ WechatSocialProvider.prototype.createSignalChannel_ = function(contact, chatroom
   return new Promise(function (resolve, reject) {
     for (var chatroom in this.client.chatrooms) { // possibly make lookup table for this
       if (this.client.chatrooms[chatroom].NickName === chatroomName) {
-        this.client.log(1, "SP: using original chatroom: " + chatroomName;
+        this.client.log(1, "SP: using original chatroom: " + chatroomName);
         resolve(chatroom);
         return; // chatroom already exists
       } else if (this.client.chatrooms[chatroom].NickName === altName) {
-        this.client.log(1, "SP: using Alt chatroom: " + chatroomName;
+        this.client.log(1, "SP: using Alt chatroom: " + chatroomName);
         resolve(chatroom);
         return; // chatroom already exists
       }
@@ -482,12 +482,12 @@ WechatSocialProvider.prototype.chatHash_ = function(wxid1, wxid2) {
   var two = wxid2.match(/wxid_(.*)/)[1];
   var temp = "";
   for (var i = 0; i < one.length; i++) { // length 14
-    temp += i % 2 == 0 ? one[i] : two[i];
+    temp += i % 2 === 0 ? one[i] : two[i];
   }
   temp = btoa(temp); // length 20
-  var result = ""
+  var result = "";
   for (i = 0; i < temp.length; i++) {
-    result += i % 2 == 0 ? temp[i] : ""; // take every other char
+    result += i % 2 === 0 ? temp[i] : ""; // take every other char
   }
   // result.length = 10;
   return CONTACT_NAME_SCHEME + result;

--- a/src/wechat-social-provider.js
+++ b/src/wechat-social-provider.js
@@ -156,7 +156,11 @@ WechatSocialProvider.prototype.initHandlers_ = function() {
         var userName = jason.iconURLPath.split("?")[1].split("&")[1].split("=")[1];
         var user = this.client.contacts[userName] || this.client.chatrooms[userName];
         var friend = this.userProfiles[user.Uin || user.wxid];
-        // TODO: detect myself here to give myself my icon.
+        if (!friend && user.wxid === this.client.contacts[this.client.thisUser.UserName].wxid) {
+          // have wxid here, but thisUser only has a Uin... 
+          // TODO: detect myself here to give myself my icon.
+          friend = this.userProfiles[this.client.thisUser.Uin];
+        }
         if (friend) {
           friend.imageData = jason.dataURL;
           this.dispatchEvent_("onUserProfile", friend);

--- a/src/wechat-social-provider.js
+++ b/src/wechat-social-provider.js
@@ -227,7 +227,7 @@ WechatSocialProvider.prototype.initHandlers_ = function() {
               this.addOrUpdateClient_(this.client.contacts[userName], "ONLINE");
             }
           }
-          this.loggedIn(this.clientStates[selfContact]);
+          this.loggedIn(this.clientStates[myself]);
         } else {
           this.client.log(-1, "wxids not fully resolved");
         }

--- a/src/wechat-social-provider.js
+++ b/src/wechat-social-provider.js
@@ -154,8 +154,9 @@ WechatSocialProvider.prototype.initHandlers_ = function() {
       try {
         var jason = JSON.parse(iconJSON);
         var userName = jason.iconURLPath.split("?")[1].split("&")[1].split("=")[1];
-        var user = this.client.contacts[userName];
+        var user = this.client.contacts[userName] || this.client.chatrooms[userName];
         var friend = this.userProfiles[user.Uin || user.wxid];
+        // TODO: detect myself here to give myself my icon.
         if (friend) {
           friend.imageData = jason.dataURL;
           this.dispatchEvent_("onUserProfile", friend);
@@ -201,6 +202,10 @@ WechatSocialProvider.prototype.initHandlers_ = function() {
           }
           if (userName !== myself) {
             this.addUserProfile_(this.client.contacts[userName]);
+          } else {
+            // TODO: is this necessary?
+            this.client.contacts[userName].wxid = wxid; 
+            this.addOrUpdateClient_(this.client.contacts[userName], "ONLINE");
           }
           // if (this.invitesSent[wxid] && this.invitesReceived[wxid]) {
           //   this.addOrUpdateClient_(this.client.contacts[userName], "ONLINE");

--- a/src/wechat-social-provider.js
+++ b/src/wechat-social-provider.js
@@ -59,10 +59,10 @@ WechatSocialProvider.prototype.initHandlers_ = function() {
    * @param {Object} message
    */
   this.client.events.onMessage = function(message) {
-    var availability = "ONLINE_WITH_OTHER_APP";
-    if (message.MsgType === this.client.HIDDENMSGTYPE) {
-      availability = "ONLINE";
-    }
+    var availability = "ONLINE";
+    // if (message.MsgType === this.client.HIDDENMSGTYPE) {
+    //   availability = "ONLINE";
+    // }
     var fromUser = this.client.contacts[message.FromUserName];
     var fromUserId = this.userProfiles[fromUser.Uin || fromUser.wxid];
     var eventMessage = {

--- a/src/wechat-social-provider.js
+++ b/src/wechat-social-provider.js
@@ -226,7 +226,7 @@ WechatSocialProvider.prototype.initHandlers_ = function() {
           // }
         }
         if (this.wxids === expected) {
-          this.client.log(0, "wxids fully resolved");
+          this.client.log(0, "wxids fully resolved: " + this.wxids + "/" + expected);
           this.client.webwxgeticon();
           for (var invitedWxid in this.invitesSent) {
             if (!this.invitesReceived[invitedWxid]) {
@@ -238,7 +238,7 @@ WechatSocialProvider.prototype.initHandlers_ = function() {
           }
           this.loggedIn(this.clientStates[myself]);
         } else {
-          this.client.log(-1, "wxids not fully resolved");
+          this.client.log(-1, "wxids not fully resolved: " + this.wxids + "/" + expected);
         }
       }
     }

--- a/src/wechat-social-provider.js
+++ b/src/wechat-social-provider.js
@@ -102,6 +102,8 @@ WechatSocialProvider.prototype.initHandlers_ = function() {
         }
 
 
+
+
         this.storage.get("invited_" + this.client.thisUser.Uin)
         .then(function(invites) {
           var iContact = invites[fromUserId];
@@ -139,10 +141,13 @@ WechatSocialProvider.prototype.initHandlers_ = function() {
             delete this.inviteds[fromUserId];
             this.storage.set("invited_" + this.client.thisUser.Uin, this.inviteds);
           }
+
         }.bind(this), this.client.handleError.bind(this.client));
+        return;
       }
     } catch(e) {
-      console.error(e); // don't want to kill uProxy, just means we haven't gotten an invite message
+      //console.error(e);
+      return; // don't want to kill uProxy, just means we haven't gotten an invite message
     }
     this.client.log(5, eventMessage.message, -1);
     this.dispatchEvent_("onMessage", eventMessage);

--- a/src/wechat-social-provider.js
+++ b/src/wechat-social-provider.js
@@ -373,7 +373,6 @@ WechatSocialProvider.prototype.acceptUserInvitation = function(invite) {
 
 // This is just a stub for how some of the invite process will go.
 WechatSocialProvider.prototype.inviteUser = function(contact) {
-  console.log(contact);
   return new Promise(function (resolve, reject) {
     var invisible_invite = this.createInvisibleInvite(MESSAGE_TYPE.INVITE, contact);
     if (this.invitesReceived[contact]) {
@@ -381,9 +380,14 @@ WechatSocialProvider.prototype.inviteUser = function(contact) {
       this.client.webwxsendmsg(invisible_invite);
       return;
     }
+    var friendName = "friend";
+    if (this.client.contacts[this.wxidToUsernameMap[contact]] &&
+        this.client.contacts[this.wxidToUsernameMap[contact]].NickName) {
+      friendName = this.client.contacts[this.wxidToUsernameMap[contact]].NickName;
+    }
     var plaintext_invite = {
         "type": 1,
-        "content": "Join me on uProxy!", //"Hey " + this.client.contacts[contact].NickName + "! You should use uProxy!", // FIXME
+        "content": "Hi " + friendName + "! I'd like to use uProxy with you. You can find more information at www.uproxy.org, or ask me about it!",
         "recipient": this.wxidToUsernameMap[contact]
     };
     this.client.webwxsendmsg(invisible_invite);

--- a/test.js
+++ b/test.js
@@ -1,12 +1,15 @@
-var foo = 1;
-var bar = undefined;
-var baz = '';
+console.log("testing...");
 
-var thing = {
-  "blah": foo || bar
-};
+function one() {
+  return new Promise(function(resolve, reject) {
+    two().then(resolve, reject);
+  });
+}
 
-console.log(0);
-console.log(thing.one);
-console.log('');
-console.log(thing.blah);
+function two() {
+  return new Promise(function(resolve, reject) {
+    resolve("herp");
+  });
+}
+
+one().then(console.log);


### PR DESCRIPTION
Invite v1 implementation:
- users become friends if they both mutually invite each other to be uProxy contacts
  - invites sent and received are tracked by this.invitesSent and this.invitesReceived (these are also saved in local storage)
  - this.invitesSent and this.invitesReceived are maps from WXIDs (a unique, fixed identifier for each contact) to the timestamp of when the invite was created
  - if a contact's WXID exists in a user's this.invitesSent _and_ this.invitesReceived, then that contact is a uProxy friend
- users choose which of their WeChat contacts to invite via the uProxy UI (https://github.com/uProxy/uproxy/pull/2043), which sends invite messages over WeChat
  - the messages are sent with type "51" which should make the messages invisible, although this has been flaky
- only inviteUser is implemented; acceptUserInvitation should be implemented when we have a concept of "accepting" invites rather than sending reciprocal invites

Invites get tricky because you might send invites to offline friends (WeChat does not yet have presence/a heartbeat). To resolve this, two things were necessary:
(1) On login, resend invites to all users who are in invitesSent but not in invitesReceived
(2) If we receive an invite from someone in invitesSent but not invitesReceived, assume they did not receive your invite, and resend an invite back.

**Both invites sent to online users.**
A and B are both online.
A sends invite to B.
B receives invite.
B sends invite to A. A is now a friend.
A receives invite. B is now a friend.
(Because of (2) above, A sends another invite back to B, because it is not sure if B received the original invite, but this additional invite effectively does nothing.)

**One invite is sent to offline user.**
A is online. B is offline.
A sends invite to B.
B comes online.
B sends invite to A.
A receives invite. B is now a friend.
Again, because of (2) above, A sends another invite back to B.
B receives invite. A is now a friend.

**Both invites are sent to offline users; they become friends when they are both online together.**
A and B are both offline.
A comes online.
A sends invite to B.
A goes offline.
B comes online.
B sends invite to A.
A comes online.
Because of (1), A sends an invite to B.
B receives invite. A is now a friend.
Because of (2), B sends another invite back to A.
A receives invite. B is now a friend.

The reason (2) doesn't cause an infinite loop of invites is that we have two types of invites. INVITE and RETURN_INVITE. Users only respond to INVITE's with RETURN_INVITE's.

Another note: this removes the chatrooms, so would it be better if this is in another branch?
Also: investigate chatroom icon errors?
